### PR TITLE
Fix latex filter tests

### DIFF
--- a/src/formatted_text/formatted_text.rs
+++ b/src/formatted_text/formatted_text.rs
@@ -60,7 +60,7 @@ fn latex_to_html(latex: &str, theorems: &Vec<Theorem>) -> Result<String, String>
 
     let pandoc_output = run_with_timeout(
         "pandoc",
-        &["--from=latex", "--to=html", "--mathjax"],
+        &["--from=latex", "--to=html", "--mathjax", "--wrap=none"],
         Some(&preprocessed.as_str()),
         Duration::from_secs(1),
     );

--- a/src/formatted_text/pandoc_latex_filters.rs
+++ b/src/formatted_text/pandoc_latex_filters.rs
@@ -78,9 +78,9 @@ impl PandocFilter for EnvFilter {
                     result.push_str(&format!("\\textbf{{{}}}. ", theorem.label(theorem_counter)));
                 } else if env_name == "equation" {
                     result.push_str(r"$$\begin{equation}");
-                } else if env_name == "problem" || env_name == "solution" {
-                    // ignore extra parameters
-                    result.push_str(format!("\\begin{{{}}}", env_name).as_str());
+                } else if env_name == "problem" || env_name == "solution" || env_name == "hint" {
+                    // Ignore these environments entirely
+                    result.push_str("");
                 } else {
                     result.push_str(s);
                 }
@@ -123,6 +123,8 @@ impl PandocFilter for EnvFilter {
                     result.push_str("\n");
                 } else if env_name == "equation" {
                     result.push_str(r"\end{equation}$$");
+                } else if env_name == "problem" || env_name == "solution" || env_name == "hint" {
+                    // Ignore closing tag
                 } else {
                     result.push_str(s);
                 }


### PR DESCRIPTION
## Summary
- honor special environment stripping for problems, solutions, and hints
- disable line wrapping in Pandoc output to make HTML deterministic

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683f910c0084832784ab44ecf27e785c