### PR TITLE
Add raw_math_blocks config to control math block rendering

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,15 @@ pub struct Config {
 
     #[serde(default)]
     pub theorems: Vec<Theorem>,
+
+    /// If set to true, math blocks wrapped in `$$` are left untouched by the
+    /// markdown renderer and output verbatim.
+    #[serde(default = "default_raw_math_blocks")]
+    pub raw_math_blocks: bool,
+}
+
+fn default_raw_math_blocks() -> bool {
+    false
 }
 
 impl Config {

--- a/src/content/test.rs
+++ b/src/content/test.rs
@@ -9,6 +9,7 @@ pub fn get_test_config() -> Config {
         build_dir: PathBuf::from("build"),
         template_dir: PathBuf::from("templates"),
         syntax_highlighter_theme: "base16-ocean.dark".to_string(),
+        raw_math_blocks: true,
         ..Default::default()
     }
 }

--- a/src/formatted_text/formatted_text.rs
+++ b/src/formatted_text/formatted_text.rs
@@ -86,6 +86,9 @@ fn markdown_to_html(markdown: &str, config: &Config) -> Result<String, String> {
     options.extension.alerts = true;
     options.parse.smart = true;
     options.render.unsafe_ = true;
+    if !config.raw_math_blocks {
+        options.extension.math_dollars = true;
+    }
 
     let markdown = &preprocess_expandables(markdown);
     let markdown = &preprocess_cards(markdown);
@@ -245,6 +248,17 @@ mod test_markdown_to_html {
         assert!(result_3.is_ok());
         let output_3 = result_3.unwrap();
         assert!(output_3.contains("$$\n2^5\n$$"));
+    }
+
+    #[test]
+    fn test_markdown_with_math_parsed() {
+        let mut config = get_test_config();
+        config.raw_math_blocks = false;
+        let result = markdown_to_html("$$2+2$$", &config);
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        assert!(!output.contains("$$"));
+        assert!(output.contains("data-math-style"));
     }
 
     #[test]

--- a/src/formatted_text/pandoc_latex_filters.rs
+++ b/src/formatted_text/pandoc_latex_filters.rs
@@ -141,7 +141,18 @@ impl PandocFilter for EnvFilter {
             .replace("(EQREFBEGIN)", "\\ref{")
             .replace("(EQREFEND)", "}")
             .replace(r"$$\begin{equation}", r"\begin{equation}")
-            .replace(r"\end{equation}$$", r"\end{equation}");
+            .replace(r"\end{equation}$$", r"\end{equation}")
+            .replace(
+                "<span\nclass=\"math display\"",
+                "<span class=\"math display\"",
+            )
+            .replace("<div class=\"problem\">", "")
+            .replace("<div class=\"solution\">", "")
+            .replace("<div class=\"hint\">", "")
+            .replace("</div>", "")
+            .trim()
+            .to_string()
+            + "\n";
         Ok(result)
     }
 }


### PR DESCRIPTION
## Summary
- add `raw_math_blocks` configuration option
- process Markdown math blocks via comrak when `raw_math_blocks` is false
- keep math blocks verbatim by default in tests
- clean up Pandoc output to remove unwanted wrappers
- cover behaviour with new unit tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687a0a334f2483279c1d85278958c95f