### PR TITLE
Add CI workflow for Rust tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Rust CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install pandoc
+        run: sudo apt-get update && sudo apt-get install -y pandoc
+      - name: Set up Rust
+        uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+      - name: Run tests
+        run: cargo test --verbose


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `cargo test` on push and pull requests
- install `pandoc` so the LaTeX conversion tests pass

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6881c9006f8483278172103a8dae73bf